### PR TITLE
Make the cache path configurable (and reside on the executor's PV!)

### DIFF
--- a/charts/dremio/config/dremio.conf
+++ b/charts/dremio/config/dremio.conf
@@ -47,8 +47,8 @@ services: {
   {{- if and .Values.executor.cloudCache.enabled (or (ge .Values.imageTag "4.0.0") (eq .Values.imageTag "latest")) }}
   executor: {
     cache: {
-      path.db: "/var/lib/dremio",
-      path.fs: ["/var/lib/dremio"],
+      path.db: {{ .Values.executor.cloudCache.path.db }},
+      path.fs: [{{ .Values.executor.cloudCache.path.fs }}],
       pctquota.db: {{ .Values.executor.cloudCache.quota.db_pct }},
       pctquota.fs: [{{ .Values.executor.cloudCache.quota.fs_pct }}]
     }

--- a/charts/dremio/values.yaml
+++ b/charts/dremio/values.yaml
@@ -27,6 +27,11 @@ executor:
   cloudCache:
     # Requires Dremio version 4.0.0 or later
     enabled: true
+    # Paths to Cloud Cache DB and file system. Should be a subfolder of
+    # /opt/dremio/data because the executor's volume is mounted there
+    path:
+      db: /opt/dremio/data/cache
+      fs: /opt/dremio/data/cache
     quota:
       # Percentage of the diskspace for the running Kubernetes node
       # that can be used for Cloud Cache files.


### PR DESCRIPTION
The current version of the Helm Chart does not allow you to configure the path for CCC. It is fixed to /var/lib/dremio which is unfortunate because the folder is located in the overload filesystem.

Instead, one should use a folder below /opt/dremio/data, because that is where the Persistent Volume is mounted. 

The PR fixed both by introducing two variables and setting the default folder to /opt/dremio/data/cache

Best, Tim from Software AG