### PR TITLE
Fix indentation for zookeeper annotations

### DIFF
--- a/charts/dremio_v2/templates/zookeeper.yaml
+++ b/charts/dremio_v2/templates/zookeeper.yaml
@@ -60,7 +60,7 @@ spec:
       labels:
         app: zk
         {{- include "dremio.zookeeper.podLabels" $ | nindent 8 }}
-      {{- include "dremio.zookeeper.podAnnotations" $ | nindent 8 }}
+      {{- include "dremio.zookeeper.podAnnotations" $ | nindent 6 }}
     spec:
       affinity:
         podAntiAffinity:


### PR DESCRIPTION
When adding a podAnnotation to values.yaml, helm fails with error:


```
Error: UPGRADE FAILED: error validating "": error validating data: ValidationError(StatefulSet.spec.template.metadata.labels.annotations): invalid type for io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta.labels: got "map", expected "string"
```

This was because indents were off by 2 in the zookeeper StatefulSet spec. Whoever thought templating whitespace-dependent files was a good design choice? =) 