### PR TITLE
feat: In the dremio_v2 Helm chart, support customization of the BusyBox.

### DIFF
--- a/charts/dremio_v2/docs/Values-Reference.md
+++ b/charts/dremio_v2/docs/Values-Reference.md
@@ -197,6 +197,12 @@ Type: Dictionary
 
 This section controls the deployment of Zookeeper in Kubernetes. See the [Zookeeper Values](#zookeeper-values) section.
 
+#### `busybox`
+
+Type: Dictionary
+
+This section controls the deployment of BusyBox in Kubernetes. See the [BusyBox Values](#busybox-values) section.
+
 ### Advanced Configuration
 
 #### `extraStartParams`
@@ -1470,6 +1476,7 @@ By default, the value is set to `1.0-3.4.10`.
 
 The version of Zookeeper set has been validated by Dremio to work with the Dremio software. Changing this version is not recommended unless the tag is different due to a private container registry name difference.
 
+
 ### General Configuration
 
 #### `zookeeeper.cpu` & `zookeeper.memory`
@@ -1609,3 +1616,23 @@ Type: String
 By default, this value is not set. If this value is omitted or set to an empty string, this value will be inherited from the top level `serviceAccount`.
 
 More Info: Refer to the [`serviceAccount`](#serviceaccount) section of this reference.
+
+## BusyBox Values
+
+### Image Configuration
+
+#### `busybox.image`
+
+Type: String
+
+By default, the value is set to `busybox`.
+
+The `image` refers to the location to retrieve the specific container image for BusyBox. In some cases, the `busybox.image` value may vary in corporate environments where there may be a private container registry that is used.
+
+#### `busybox.imageTag`
+
+Type: String
+
+By default, the value is set to `latest`.
+
+The version of BusyBox set has been validated by Dremio to work with the Dremio software. Changing this version is not recommended unless the tag is different due to a private container registry name difference.

--- a/charts/dremio_v2/templates/dremio-coordinator.yaml
+++ b/charts/dremio_v2/templates/dremio-coordinator.yaml
@@ -92,7 +92,7 @@ spec:
       initContainers:
       {{- include "dremio.coordinator.extraInitContainers" $ | nindent 6 }}
       - name: wait-for-dremio-master
-        image: busybox
+        image: {{ $.Values.busybox.image }}:{{ $.Values.busybox.imageTag }}
         command:  ["sh", "-c", "until nc -z dremio-client {{ $.Values.coordinator.web.port }} > /dev/null; do echo Waiting for Dremio master.; sleep 2; done;"]
       {{- if $.Values.coordinator.web.tls.enabled }}
       - name: generate-ui-keystore

--- a/charts/dremio_v2/templates/dremio-executor.yaml
+++ b/charts/dremio_v2/templates/dremio-executor.yaml
@@ -93,7 +93,7 @@ spec:
         args: ["dremio:dremio", "/opt/dremio/data"]
       {{- include "dremio.executor.cloudCache.initContainers" (list $ $engineName) | nindent 6 }}
       - name: wait-for-zookeeper
-        image: busybox
+        image: {{ $.Values.busybox.image }}:{{ $.Values.busybox.imageTag }}
         command:  ["sh", "-c", "until ping -c 1 -W 1 zk-hs > /dev/null; do echo Waiting for Zookeeper to be ready.; sleep 2; done;"]
       volumes:
       - name: dremio-config

--- a/charts/dremio_v2/templates/dremio-master.yaml
+++ b/charts/dremio_v2/templates/dremio-master.yaml
@@ -106,10 +106,10 @@ spec:
       initContainers:
       {{- include "dremio.coordinator.extraInitContainers" $ | nindent 6 }}
       - name: start-only-one-dremio-master
-        image: busybox
+        image: {{ $.Values.busybox.image }}:{{ $.Values.busybox.imageTag }}
         command: ["sh", "-c", "INDEX=${HOSTNAME##*-}; if [ $INDEX -ne 0 ]; then echo Only one master should be running.; exit 1; fi; "]
       - name: wait-for-zookeeper
-        image: busybox
+        image: {{ $.Values.busybox.image }}:{{ $.Values.busybox.imageTag }}
         command:  ["sh", "-c", "until ping -c 1 -W 1 zk-hs > /dev/null; do echo Waiting for Zookeeper to be ready.; sleep 2; done;"]
       - name: chown-data-directory
         image: {{ $.Values.image }}:{{ $.Values.imageTag }}

--- a/charts/dremio_v2/values.yaml
+++ b/charts/dremio_v2/values.yaml
@@ -276,6 +276,12 @@ zookeeper:
   #nodeSelector: {}
   #tolerations: []
 
+# BusyBox
+busybox:
+  # The BusyBox image used in the cluster.
+  image: busybox
+  imageTag: latest
+
 # Control where uploaded files are stored for Dremio.
 # For more information, see https://docs.dremio.com/deployment/distributed-storage.html
 distStorage:


### PR DESCRIPTION
This allows an air-gapped environment without access to a remote repository to leverage a local copy of the BusyBox image.