### PR TITLE
Add support to configure telemetry file and enable JMX port and hostname

### DIFF
--- a/charts/dremio_v2/templates/dremio-configmap.yaml
+++ b/charts/dremio_v2/templates/dremio-configmap.yaml
@@ -4,6 +4,10 @@ metadata:
   name: dremio-config
 data:
   {{- tpl ($.Files.Glob "config/*").AsConfig . | nindent 2 }}
+  {{- if $.Values.telemetry.enabled }}
+  dremio-telemetry.yaml: |
+  {{- $.Values.telemetry.yaml | nindent 4 }}
+  {{- end }}
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/charts/dremio_v2/templates/dremio-coordinator.yaml
+++ b/charts/dremio_v2/templates/dremio-coordinator.yaml
@@ -52,6 +52,12 @@ spec:
         {{- end }}
         {{- include "dremio.coordinator.extraVolumeMounts" $ | nindent 8 }}
         env:
+        {{- if and $.Values.telemetry.enabled (eq $.Values.telemetry.type "jmx") }}
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        {{- end }}
         - name: DREMIO_MAX_HEAP_MEMORY_SIZE_MB
           value: "{{ template "dremio.coordinator.heapMemory" $ }}"
         - name: DREMIO_MAX_DIRECT_MEMORY_SIZE_MB
@@ -65,6 +71,15 @@ spec:
             -Dservices.coordinator.master.embedded-zookeeper.enabled=false
             -Dservices.executor.enabled=false
             -Dservices.conduit.port=45679
+            {{- if and $.Values.telemetry.enabled (eq $.Values.telemetry.type "jmx") }}
+            -Dcom.sun.management.jmxremote
+            -Dcom.sun.management.jmxremote.authenticate=false
+            -Dcom.sun.management.jmxremote.ssl=false
+            -Dcom.sun.management.jmxremote.local.only=false
+            -Dcom.sun.management.jmxremote.port={{ $.Values.telemetry.jmxPort }}
+            -Dcom.sun.management.jmxremote.rmi.port={{ $.Values.telemetry.jmxPort }}
+            -Djava.rmi.server.hostname=$(POD_IP)
+            {{- end }}
         - name: AWS_CREDENTIAL_PROFILES_FILE
           value: "/opt/dremio/aws/credentials"
         - name: AWS_SHARED_CREDENTIALS_FILE
@@ -80,6 +95,10 @@ spec:
           name: server-fabric
         - containerPort: 45679
           name: server-conduit
+        {{- if and $.Values.telemetry.enabled (eq $.Values.telemetry.type "jmx") }}
+        - containerPort: {{ $.Values.telemetry.jmxPort }}
+          name: jmx-port
+        {{- end }}
         readinessProbe:
           httpGet:
             path: /

--- a/charts/dremio_v2/templates/dremio-executor.yaml
+++ b/charts/dremio_v2/templates/dremio-executor.yaml
@@ -54,6 +54,12 @@ spec:
         {{- include "dremio.executor.cloudCache.volumeMounts" (list $ $engineName) | nindent 8 }}
         {{- include "dremio.executor.extraVolumeMounts" (list $ $engineName) | nindent 8 }}
         env:
+        {{- if and $.Values.telemetry.enabled (eq $.Values.telemetry.type "jmx") }}
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        {{- end }}
         - name: DREMIO_MAX_HEAP_MEMORY_SIZE_MB
           value: "{{ template "dremio.executor.heapMemory" (list $ $engineName) }}"
         - name: DREMIO_MAX_DIRECT_MEMORY_SIZE_MB
@@ -68,6 +74,15 @@ spec:
             -Dservices.executor.enabled=true
             -Dservices.conduit.port=45679
             -Dservices.node-tag={{ $engineName }}
+            {{- if and $.Values.telemetry.enabled (eq $.Values.telemetry.type "jmx") }}
+            -Dcom.sun.management.jmxremote
+            -Dcom.sun.management.jmxremote.authenticate=false
+            -Dcom.sun.management.jmxremote.ssl=false
+            -Dcom.sun.management.jmxremote.local.only=false
+            -Dcom.sun.management.jmxremote.port={{ $.Values.telemetry.jmxPort }}
+            -Dcom.sun.management.jmxremote.rmi.port={{ $.Values.telemetry.jmxPort }}
+            -Djava.rmi.server.hostname=$(POD_IP)
+            {{- end }}
         - name: AWS_CREDENTIAL_PROFILES_FILE
           value: "/opt/dremio/aws/credentials"
         - name: AWS_SHARED_CREDENTIALS_FILE
@@ -79,6 +94,10 @@ spec:
           name: server-fabric
         - containerPort: 45679
           name: server-conduit
+        {{- if and $.Values.telemetry.enabled (eq $.Values.telemetry.type "jmx") }}
+        - containerPort: {{ $.Values.telemetry.jmxPort }}
+          name: jmx-port
+        {{- end }}
       initContainers:
       {{- include "dremio.executor.extraInitContainers" (list $ $engineName) | nindent 6 }}
       - name: chown-data-directory

--- a/charts/dremio_v2/templates/dremio-master.yaml
+++ b/charts/dremio_v2/templates/dremio-master.yaml
@@ -63,6 +63,12 @@ spec:
         {{- end }}
         {{- include "dremio.coordinator.extraVolumeMounts" $ | nindent 8 }}
         env:
+        {{- if and $.Values.telemetry.enabled (eq $.Values.telemetry.type "jmx") }}
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        {{- end }}
         - name: DREMIO_MAX_HEAP_MEMORY_SIZE_MB
           value: "{{ template "dremio.coordinator.heapMemory" $ }}"
         - name: DREMIO_MAX_DIRECT_MEMORY_SIZE_MB
@@ -76,6 +82,15 @@ spec:
             -Dservices.coordinator.master.embedded-zookeeper.enabled=false
             -Dservices.executor.enabled=false
             -Dservices.conduit.port=45679
+            {{- if and $.Values.telemetry.enabled (eq $.Values.telemetry.type "jmx") }}
+            -Dcom.sun.management.jmxremote
+            -Dcom.sun.management.jmxremote.authenticate=false
+            -Dcom.sun.management.jmxremote.ssl=false
+            -Dcom.sun.management.jmxremote.local.only=false
+            -Dcom.sun.management.jmxremote.port={{ $.Values.telemetry.jmxPort }}
+            -Dcom.sun.management.jmxremote.rmi.port={{ $.Values.telemetry.jmxPort }}
+            -Djava.rmi.server.hostname=$(POD_IP)
+            {{- end }}
         - name: AWS_CREDENTIAL_PROFILES_FILE
           value: "/opt/dremio/aws/credentials"
         - name: AWS_SHARED_CREDENTIALS_FILE
@@ -94,6 +109,10 @@ spec:
           name: server-fabric
         - containerPort: 45679
           name: server-conduit
+        {{- if and $.Values.telemetry.enabled (eq $.Values.telemetry.type "jmx") }}
+        - containerPort: {{ $.Values.telemetry.jmxPort }}
+          name: jmx-port
+        {{- end }}
         readinessProbe:
           httpGet:
             path: /

--- a/charts/dremio_v2/values.yaml
+++ b/charts/dremio_v2/values.yaml
@@ -475,3 +475,23 @@ service:
 # https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
 # imagePullSecrets:
 #  - secretname
+
+telemetry:
+  # enable telemetry configurators
+  enabled: false
+  # Supported value cloudwatch | prometheus | slf4j | jmx
+  # for non JMX telemetry configurator, jar file must be pre-allocated in `/jars/3rdparty`
+  # fork docker image or use extra volumes to add it.
+#  type: "jmx"
+#  jmxPort: 9072
+  # multiline value for dremio-telemtry.yaml
+#  yaml: |-
+#    auto-reload:
+#      enabled: True
+#      period: 500
+#      unit: MILLISECONDS
+#
+#    metrics:
+#      - name: jobs
+#        reporter:
+#          type: jmx


### PR DESCRIPTION
* give ability to specify content of dremio-telemetry.yaml
* add POD_ID to have ability enable jmx `-Djava.rmi.server.hostname=$(POD_IP)`
* add all JMX necessary java options(-D) 
* add flag to enable disable this feautre