### PR TITLE
Add ability to specify global image registry in values

### DIFF
--- a/charts/dremio_v2/docs/Values-Reference.md
+++ b/charts/dremio_v2/docs/Values-Reference.md
@@ -230,7 +230,7 @@ For example, to have an `initContainer` with the Dremio image, you can specify t
 ```yaml
 extraInitContainers: |
   - name: dremio-hello-world
-    image: {{ $.Values.image }}:{{ $.Values.imageTag }}
+    image: {{ $.Values.global.imageRegistry }}{{ $.Values.image }}:{{ $.Values.imageTag }}
     command: ["echo", "Hello World"]
 [...]
 ```
@@ -565,7 +565,7 @@ coordinator:
   [...]
   extraInitContainers: |
     - name: dremio-hello-world
-      image: {{ $.Values.image }}:{{ $.Values.imageTag }}
+      image: {{ $.Values.global.imageRegistry }}{{ $.Values.image }}:{{ $.Values.imageTag }}
       command: ["echo", "Hello World"]
 [...]
 ```
@@ -842,7 +842,7 @@ coordinator:
   [...]
   extraInitContainers: |
     - name: dremio-hello-world
-      image: {{ $.Values.image }}:{{ $.Values.imageTag }}
+      image: {{ $.Values.global.imageRegistry }}{{ $.Values.image }}:{{ $.Values.imageTag }}
       command: ["echo", "Hello World"]
 [...]
 ```
@@ -940,7 +940,7 @@ executor:
 
       extraInitContainers: |
         - name: dremio-hello-world
-          image: {{ $.Values.image }}:{{ $.Values.imageTag }}
+          image: {{ $.Values.global.imageRegistry }}{{ $.Values.image }}:{{ $.Values.imageTag }}
           command: ["echo", "Hello World"]
 
       extraVolumes:

--- a/charts/dremio_v2/templates/dremio-admin.yaml
+++ b/charts/dremio_v2/templates/dremio-admin.yaml
@@ -14,7 +14,7 @@ metadata:
 spec:
   containers:
   - name: dremio-admin
-    image: {{ $.Values.image }}:{{ $.Values.imageTag }}
+    image: {{ $.Values.global.imageRegistry }}{{ $.Values.image }}:{{ $.Values.imageTag }}
     imagePullPolicy: IfNotPresent
     stdin: true
     tty: true

--- a/charts/dremio_v2/templates/dremio-coordinator.yaml
+++ b/charts/dremio_v2/templates/dremio-coordinator.yaml
@@ -29,7 +29,7 @@ spec:
       {{- include "dremio.coordinator.tolerations" $ | nindent 6 }}
       containers:
       - name: dremio-coordinator
-        image: {{ $.Values.image }}:{{ $.Values.imageTag }}
+        image: {{ $.Values.global.imageRegistry }}{{ $.Values.image }}:{{ $.Values.imageTag }}
         imagePullPolicy: IfNotPresent
         resources:
           requests:
@@ -96,7 +96,7 @@ spec:
         command:  ["sh", "-c", "until nc -z dremio-client {{ $.Values.coordinator.web.port }} > /dev/null; do echo Waiting for Dremio master.; sleep 2; done;"]
       {{- if $.Values.coordinator.web.tls.enabled }}
       - name: generate-ui-keystore
-        image: {{ $.Values.image }}:{{ $.Values.imageTag }}
+        image: {{ $.Values.global.imageRegistry }}{{ $.Values.image }}:{{ $.Values.imageTag }}
         imagePullPolicy: IfNotPresent
         volumeMounts:
         - name: dremio-tls
@@ -108,7 +108,7 @@ spec:
       {{- end }}
       {{- if $.Values.coordinator.client.tls.enabled }}
       - name: generate-client-keystore
-        image: {{ $.Values.image }}:{{ $.Values.imageTag }}
+        image: {{ $.Values.global.imageRegistry }}{{ $.Values.image }}:{{ $.Values.imageTag }}
         imagePullPolicy: IfNotPresent
         volumeMounts:
         - name: dremio-tls
@@ -120,7 +120,7 @@ spec:
       {{- end }}
       {{- if $.Values.coordinator.flight.tls.enabled }}
       - name: generate-flight-keystore
-        image: {{ $.Values.image }}:{{ $.Values.imageTag }}
+        image: {{ $.Values.global.imageRegistry }}{{ $.Values.image }}:{{ $.Values.imageTag }}
         imagePullPolicy: IfNotPresent
         volumeMounts:
         - name: dremio-tls

--- a/charts/dremio_v2/templates/dremio-executor.yaml
+++ b/charts/dremio_v2/templates/dremio-executor.yaml
@@ -32,7 +32,7 @@ spec:
       {{- include "dremio.executor.tolerations" (list $ $engineName) | nindent 6}}
       containers:
       - name: dremio-executor
-        image: {{ $.Values.image }}:{{ $.Values.imageTag }}
+        image: {{ $.Values.global.imageRegistry }}{{ $.Values.image }}:{{ $.Values.imageTag }}
         imagePullPolicy: IfNotPresent
         resources:
           requests:
@@ -82,7 +82,7 @@ spec:
       initContainers:
       {{- include "dremio.executor.extraInitContainers" (list $ $engineName) | nindent 6 }}
       - name: chown-data-directory
-        image: {{ $.Values.image }}:{{ $.Values.imageTag }}
+        image: {{ $.Values.global.imageRegistry }}{{ $.Values.image }}:{{ $.Values.imageTag }}
         imagePullPolicy: IfNotPresent
         securityContext:
           runAsUser: 0

--- a/charts/dremio_v2/templates/dremio-master.yaml
+++ b/charts/dremio_v2/templates/dremio-master.yaml
@@ -38,7 +38,7 @@ spec:
       {{- include "dremio.coordinator.tolerations" $ | nindent 6 }}
       containers:
       - name: dremio-master-coordinator
-        image: {{ $.Values.image }}:{{ $.Values.imageTag }}
+        image: {{ $.Values.global.imageRegistry }}{{ $.Values.image }}:{{ $.Values.imageTag }}
         imagePullPolicy: IfNotPresent
         resources:
           requests:
@@ -112,7 +112,7 @@ spec:
         image: busybox
         command:  ["sh", "-c", "until ping -c 1 -W 1 zk-hs > /dev/null; do echo Waiting for Zookeeper to be ready.; sleep 2; done;"]
       - name: chown-data-directory
-        image: {{ $.Values.image }}:{{ $.Values.imageTag }}
+        image: {{ $.Values.global.imageRegistry }}{{ $.Values.image }}:{{ $.Values.imageTag }}
         imagePullPolicy: IfNotPresent
         securityContext:
           runAsUser: 0
@@ -124,7 +124,7 @@ spec:
         - "dremio:dremio"
         - "/opt/dremio/data"
       - name: upgrade-task
-        image: {{ $.Values.image }}:{{ $.Values.imageTag }}
+        image: {{ $.Values.global.imageRegistry }}{{ $.Values.image }}:{{ $.Values.imageTag }}
         imagePullPolicy: IfNotPresent
         volumeMounts:
         - name: dremio-master-volume
@@ -136,7 +136,7 @@ spec:
         - "upgrade"
       {{- if $.Values.coordinator.web.tls.enabled }}
       - name: generate-ui-keystore
-        image: {{ $.Values.image }}:{{ $.Values.imageTag }}
+        image: {{ $.Values.global.imageRegistry }}{{ $.Values.image }}:{{ $.Values.imageTag }}
         imagePullPolicy: IfNotPresent
         volumeMounts:
         - name: dremio-tls
@@ -148,7 +148,7 @@ spec:
       {{- end }}
       {{- if $.Values.coordinator.client.tls.enabled }}
       - name: generate-client-keystore
-        image: {{ $.Values.image }}:{{ $.Values.imageTag }}
+        image: {{ $.Values.global.imageRegistry }}{{ $.Values.image }}:{{ $.Values.imageTag }}
         imagePullPolicy: IfNotPresent
         volumeMounts:
         - name: dremio-tls
@@ -160,7 +160,7 @@ spec:
       {{- end }}
       {{- if $.Values.coordinator.flight.tls.enabled }}
       - name: generate-flight-keystore
-        image: {{ $.Values.image }}:{{ $.Values.imageTag }}
+        image: {{ $.Values.global.imageRegistry }}{{ $.Values.image }}:{{ $.Values.imageTag }}
         imagePullPolicy: IfNotPresent
         volumeMounts:
         - name: dremio-tls

--- a/charts/dremio_v2/values.yaml
+++ b/charts/dremio_v2/values.yaml
@@ -16,6 +16,12 @@
 image: dremio/dremio-oss
 imageTag: latest
 
+# Global image registry
+# make sure to add slash in the end of URL
+# Example: your_private_global_registry:8080/
+global:
+ imageRegistry: ""
+
 # Annotations, labels, node selectors, and tolerations
 #
 # annotations: Annotations are applied to the StatefulSets that are deployed.
@@ -62,7 +68,7 @@ coordinator:
   # Uncomment the below lines to use a custom set of extra init containers for the coordinator.
   #extraInitContainers: |
   #  - name: extra-init-container
-  #    image: {{ $.Values.image }}:{{ $.Values.imageTag }}
+  #    image: {{ $.Values.global.imageRegistry }}{{ $.Values.image }}:{{ $.Values.imageTag }}
   #    command: ["echo", "Hello World"]
 
   # Extra Volumes
@@ -152,7 +158,7 @@ executor:
   # Uncomment the below lines to use a custom set of extra init containers for executors.
   #extraInitContainers: |
   #  - name: extra-init-container
-  #    image: {{ $.Values.image }}:{{ $.Values.imageTag }}
+  #    image: {{ $.Values.global.imageRegistry }}{{ $.Values.image }}:{{ $.Values.imageTag }}
   #    command: ["echo", "Hello World"]
 
   # Extra Volumes
@@ -230,7 +236,7 @@ executor:
   #
   #     extraInitContainers: |
   #       - name: extra-init-container
-  #         image: {{ $.Values.image }}:{{ $.Values.imageTag }}
+  #         image: {{ $.Values.global.imageRegistry }}{{ $.Values.image }}:{{ $.Values.imageTag }}
   #         command: ["echo", "Hello World"]
   #
   #
@@ -425,7 +431,7 @@ distStorage:
 # Uncomment the below lines to provide extra init containers to be run first.
 #extraInitContainers: |
 #  - name: extra-init-container
-#    image: {{ $.Values.image }}:{{ $.Values.imageTag }}
+#    image: {{ $.Values.global.imageRegistry }}{{ $.Values.image }}:{{ $.Values.imageTag }}
 #    command: ["echo", "Hello World"]
 
 # Kubernetes Service Account


### PR DESCRIPTION
Currently, executors are using some images like busybox from the default Docker registry, and deployment can fail on a pretty big cluster due to the limitation of the number of requests to Docker.
We are adding the ability to specify a global image registry for all images.