### PR TITLE
Setting `imageTag` to a number causes `helm install` to fail

### DIFF
--- a/charts/dremio_v2/values.yaml
+++ b/charts/dremio_v2/values.yaml
@@ -9,6 +9,9 @@
 # tags in the form X.Y (i.e. 21.1) are updated with the latest
 # patch version released.
 #
+# If you use the form X.Y (e.g. 20.1) then you
+# must enclose it in double-quotes (e.g. "20.1")
+#
 # Using the image tag latest or in the form X.Y
 # will potentially cause Dremio to upgrade versions
 # automatically during redeployments and may negatively impact


### PR DESCRIPTION
If you set `imageTag` to something that can be interpreted as a number (e.g. 20 or 20.1 ) then helm interprets it as a number, and the comparison on line 18 in dremio.conf  (` {{- if eq $.Values.imageTag "latest" }}`) fails because it is comparing a number to a string.

Enclosing the number in quotes coerces it into a string and the comparison is fine.