### PR TITLE
DX-59439 Incorrect Memory Calculation causing Kube OOM crashes

### DIFF
--- a/charts/dremio_v2/templates/_helpers_executor.tpl
+++ b/charts/dremio_v2/templates/_helpers_executor.tpl
@@ -58,7 +58,7 @@ Executor - Memory Resource Request
 {{- $engineName := index . 1 -}}
 {{- $engineConfiguration := default (dict) (get (default (dict) $context.Values.executor.engineOverride) $engineName) -}}
 {{- $engineMemory := default ($context.Values.executor.memory) $engineConfiguration.memory -}}
-{{- $engineMemory -}}M
+{{- $engineMemory -}}Mi
 {{- end -}}
 
 {{/*

--- a/charts/dremio_v2/templates/dremio-coordinator.yaml
+++ b/charts/dremio_v2/templates/dremio-coordinator.yaml
@@ -34,7 +34,7 @@ spec:
         resources:
           requests:
             cpu: {{ $.Values.coordinator.cpu }}
-            memory: {{ $.Values.coordinator.memory }}M
+            memory: {{ $.Values.coordinator.memory }}Mi
         volumeMounts:
         - name: dremio-config
           mountPath: /opt/dremio/conf

--- a/charts/dremio_v2/templates/dremio-master.yaml
+++ b/charts/dremio_v2/templates/dremio-master.yaml
@@ -43,7 +43,7 @@ spec:
         resources:
           requests:
             cpu: {{ $.Values.coordinator.cpu }}
-            memory: {{ $.Values.coordinator.memory }}M
+            memory: {{ $.Values.coordinator.memory }}Mi
         volumeMounts:
         - name: dremio-master-volume
           mountPath: /opt/dremio/data


### PR DESCRIPTION
M needs to be replaced by Mi.
M = 1000
Mi = 1024

https://kubernetes.io/docs/tasks/configure-pod-container/assign-memory-resource/#specify-a-memory-request-and-a-memory-limit