### PR TITLE
add web port to dremio-coordinator

### DIFF
--- a/charts/dremio_v2/templates/dremio-coordinator.yaml
+++ b/charts/dremio_v2/templates/dremio-coordinator.yaml
@@ -72,6 +72,8 @@ spec:
         command: ["/opt/dremio/bin/dremio"]
         args: ["start-fg"]
         ports:
+        - containerPort: 9047
+          name: web
         - containerPort: 31010
           name: client
         - containerPort: 32010


### PR DESCRIPTION
# What's changed?
Based on [dremio-coordinator.yaml](https://github.com/dremio/dremio-cloud-tools/blob/d82811a0d25f1b81ff237f856fda151057ce6609/charts/dremio_v2/templates/dremio-coordinator.yaml#L74-L82) helm chart, I am seeing that web port 9047 isn’t in the container port. This implies that the load balancer does not balance REST API requests across master and coordinator nodes, contradicting the deployment architectural diagram.
![Untitled](https://github.com/dremio/dremio-cloud-tools/assets/28745975/43f2e1b3-bc9a-4659-a099-ef40d34aaec3)