### PR TITLE
Added OAuth 2.0 support to Helm chart v2

### DIFF
--- a/charts/dremio_v2/config/dremio.conf
+++ b/charts/dremio_v2/config/dremio.conf
@@ -102,3 +102,8 @@ services.flight.ssl.enabled: true
 services.flight.ssl.auto-certificate.enabled: false
 services.flight.ssl.keyStore: "/opt/dremio/tls/flight.pkcs12"
 {{- end }}
+
+{{- if $.Values.coordinator.web.oauth.enabled }}
+services.coordinator.web.auth.type: "oauth"
+services.coordinator.web.auth.config: "/opt/dremio/conf/oauth.json"
+{{- end }}

--- a/charts/dremio_v2/config/oauth.json
+++ b/charts/dremio_v2/config/oauth.json
@@ -1,0 +1,11 @@
+{{- if $.Values.coordinator.web.oauth.enabled }}
+{
+    "clientId": {{ required "OAuth 2.0 Client ID required" $.Values.coordinator.web.oauth.clientId | quote }},
+    "clientSecret": {{ required "OAuth 2.0 Client Secret required" $.Values.coordinator.web.oauth.clientSecret | quote }},
+    "redirectUrl": {{ required "OAuth 2.0 Redirect URL required" $.Values.coordinator.web.oauth.redirectUrl | quote }},
+    "authorityUrl": {{ required "OAuth 2.0 Authority URL required" $.Values.coordinator.web.oauth.authorityUrl | quote }},
+    "scope": {{ required "OAuth 2.0 Scopes required" $.Values.coordinator.web.oauth.scope | join " " | quote }},
+    "jwtClaims": {{ $.Values.coordinator.web.oauth.jwtClaims | default dict | toJson }},
+    "parameters": {{ $.Values.coordinator.web.oauth.parameters | default list | toJson }}
+}
+{{- end }}

--- a/charts/dremio_v2/values.yaml
+++ b/charts/dremio_v2/values.yaml
@@ -96,6 +96,43 @@ coordinator:
       # To create a TLS secret, use the following command:
       # kubectl create secret tls ${TLS_SECRET_NAME} --key ${KEY_FILE} --cert ${CERT_FILE}
       secret: dremio-tls-secret-ui
+    
+    oauth:
+      # To enable OAuth 2.0 for the web UI, set the enabled flag to true and provide
+      # the following required information
+      enabled: false
+
+      # required, it is based on the OpenID provider.
+      #clientId: ""
+      
+      # required, it is based on the OpenID provider.
+      # NOTE: In Dremio 24+, clientSecret can be encrypted using the dremio-admin encrypt CLI command.
+      #clientSecret: ""
+      
+      # required, the URL where Dremio is hosted. The URL must match the redirect url set in the OpenID Provider.
+      # typically ends with /sso (e. g. https://<dremio-url>/sso)
+      #redirectUrl: ""
+
+      # required, the location where Dremio can find the OpenID discovery document. For example, Google’s location 
+      # is https://accounts.google.com/.well-known/openid-configuration and the authorityUrl therefore to use is 
+      # https://accounts.google.com, the base location of the well-known directory.
+      #authorityUrl: ""
+      
+      # optional, it is based on the OpenID provider. openid scope is always required, other scopes can vary by provider.
+      # defaults to openid
+      scope:
+      - openid
+      
+      # optional, maps fields from the JWT token to fields Dremio requires. The only field currently required 
+      # is userName, which you should set to the field in JWT that contains the user’s username.
+      # defaults to using the email as the userName
+      jwtClaims:
+        userName: email
+      
+      # optional, any additional parameters required by the OpenID providers.
+      #parameters:
+      #- name: access_type
+      #  value: offline
 
   # ODBC/JDBC Client
   client:


### PR DESCRIPTION
I introduced new values for the Helm chart v2 that allows enabling SSO via OAuth 2.0 support according to the OpenID documentation here: https://docs.dremio.com/current/get-started/cluster-deployments/customizing-configuration/dremio-conf/sso-config

My test setup uses Keycloak as IdP and I was able to validate my changes using this approach.