### PR TITLE
Add appProtocol field to dremio-client service

### DIFF
--- a/charts/dremio_v2/Chart.yaml
+++ b/charts/dremio_v2/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: "v1"
 name: "dremio"
-version: "2.0.0"
+version: "2.0.1"
 keywords:
   - dremio
   - data

--- a/charts/dremio_v2/templates/dremio-service-client.yaml
+++ b/charts/dremio_v2/templates/dremio-service-client.yaml
@@ -17,6 +17,7 @@ spec:
   - port: {{ $.Values.coordinator.flight.port | default 32010 }}
     targetPort: flight
     name: flight
+    appProtocol: http2
   selector:
     app: dremio-coordinator
   type: {{ $.Values.service.type }}


### PR DESCRIPTION
We run the Dremio setup behind Istio, and Istio doesn't automatically upgrade GRPC traffic to HTTP2 because it doesn't recognise the port name "flight". Therefore, we explicitly upgrade the connection to HTTP2 in the k8s service resource.