### PR TITLE
DX-94016: Bump Zookeeper version

### DIFF
--- a/charts/dremio_v2/values.yaml
+++ b/charts/dremio_v2/values.yaml
@@ -314,7 +314,7 @@ executor:
 zookeeper:
   # The Zookeeper image used in the cluster.
   image: zookeeper
-  imageTag: 3.8.3-jre-17
+  imageTag: 3.8.4-jre-17
 
   # CPU & Memory
   # Memory allocated to each zookeeper, expressed in MB.


### PR DESCRIPTION
Some CVEs were identified related to Zookeeper docker image 3.8.3-jre-17. This change upgrades the Zookeeper image to 3.8.4-jre-17, which version mitigates the reported CVEs.

This only bumps the Zookeeper image (ZK server) and does not affect Dremio client and ZK embedded version.
